### PR TITLE
Replace py7zr with zipfile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyyaml
 pywin32
-py7zr
 brotlicffi
 psutil

--- a/src/main.py
+++ b/src/main.py
@@ -6,8 +6,7 @@ from yaml_parser import readYamlFile
 from services import checkServiceStartupAndReset, checkServiceExistsAndDelete
 from task_scheduler import checkTaskExistsAndDelete, checkTasksFolderExistsAndDelete
 from subprocess import run, DEVNULL
-from py7zr import SevenZipFile
-from py7zr.exceptions import UnsupportedCompressionMethodError
+from zipfile import ZipFile
 
 
 checks_state = {"registry": False, "files": False, "services": False, "schdtasks": False}
@@ -84,14 +83,9 @@ def parse_args():
 
 
 def extract_apbx(path):
-    run(rf'copy {path} .\playbook.7z', check=True, shell=True, stdout=DEVNULL)
-    with SevenZipFile('playbook.7z', mode='r', password='malte') as file:
+    with ZipFile(path, mode='r') as file:
         run(r'mkdir .\playbook', check=True, shell=True, stdout=DEVNULL)
-        try:
-            file.extractall(path='./playbook')
-        # I don't know why, but it throws this error even though it works
-        except UnsupportedCompressionMethodError:
-            pass
+        file.extractall(path='.\playbook', pwd=b'malte')
 
 
 def main():


### PR DESCRIPTION
I experienced some issues with py7zr when trying to use this tool.

When trying to open playbook.7z it threw the error : `py7zr.exceptions.Bad7zFile: not a 7z file`